### PR TITLE
Index "domain.com." as well as "domain.com" when enumerating domains

### DIFF
--- a/client.go
+++ b/client.go
@@ -182,6 +182,7 @@ func (c *Client) EnumerateDomains() (map[string]int, error) {
 
 	for _, domain := range respDomains.Domains {
 		domains[domain.Name] = domain.ID
+		domains[domain.Name + "."] = domain.ID
 	}
 
 	return domains, nil


### PR DESCRIPTION
When this is used with `libdns/dnsmadeeasy` (i.e. Caddy), Caddy attempts to look up `domain.com.`, which `EnumerateDomains` doesn't see because it's just grabbing `/dns/managed` and that returns the names without the final dot.  This pull request adds both regular and final-dot versions to the lookup table so `IdForDomain` will be able to find the correct domain ID for `domain.com.`.